### PR TITLE
Make sure messages are LF separated on all platforms

### DIFF
--- a/src/Liuggio/StatsdClient/StatsdClient.php
+++ b/src/Liuggio/StatsdClient/StatsdClient.php
@@ -77,7 +77,7 @@ class StatsdClient implements StatsdClientInterface
             //going to modifying the existing
             $separator = '';
             if ($sizeResult > 0) {
-                $separator = PHP_EOL;
+                $separator = "\n";
             }
             $oldLastItem = sprintf("%s%s%s", $oldLastItem, $separator, $message);
             array_push($result, $oldLastItem);


### PR DESCRIPTION
I don't think it's by design that you'd send CRLF separated messages on windows?
