### PR TITLE
[WIP] [2.0] alpha release - packet Reducer as decorator, Handler to solve buffering and simplify usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,8 @@ Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there'
 
 - `StatsdClient` sends the created objects via the `Sender` to the server
 
+- `Handler` could be
+
 ## Why use this library instead the [statsd/php-example](https://github.com/etsy/statsd/blob/master/examples/php-example.php)?
 
 - You are wise.
@@ -28,20 +30,24 @@ Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there'
 
 - You do want to debug the packets, and using `SysLogSender` the packets will be logged in your `syslog` log (on debian-like distro: `tail -f /var/log/syslog`)
 
-
 ## Example
 
-1. create the Sender
+``` php
+$sender = new EchoSender();                 // new sender dumping to the standard output.
+//$sender = SocketSender('localhost', 8126) // new sender using socket.
+$client = new StatsdClient($sender);        // the client uses the sender to send data
+// add client decorator to reduce packets.
+$client = new PacketReducer($client);       // the decorator reduces the packet to send
+$factory = new StatsdDataFactory();         // the factory create the packet
 
-2. create the Client
-
-3. optional - decorate the client with the PacketReducer
-
-4. create the Factory
-
-5. the Factory will help you to create data
-
-6. the Client will send the data
+$sendHandler = new SendHandler($client, $factory); // the Handler will create and send the data
+$sendHandler->timing('usageTime', 100);     // create the timing object and send it.
+// ...
+$bufferHandler = new BufferHandler($client, $factory); // this handler will buffer the data
+$bufferHandler->timing('usageTime', 100);   // create and buffers the data
+// ...
+$bufferHandler->send();                     // sends all the buffered data
+```
 
 ### Standard Usage
 
@@ -71,41 +77,18 @@ $data[] = $factory->set('uniques', 765);
 $client->send($data);
 ```
 
+more info at [example.php](src/example/example.php)
+
 ### Usage with Monolog
 
-```php
-use Liuggio\StatsdClient\StatsdClient,
-    Liuggio\StatsdClient\Factory\StatsdDataFactory,
-    Liuggio\StatsdClient\Sender\SocketSender;
-// use Liuggio\StatsdClient\PacketReducer;
-// use Liuggio\StatsdClient\Sender\SysLogSender;
-
-use Monolog\Logger;
-use Liuggio\StatsdClient\Monolog\Handler\StatsDHandler;
-
-$sender = new SocketSender(/*'localhost', 8126, 'udp'*/);
-// $sender = new SysLogSender(); // enabling this, the packet will not send over the socket
-$client = new StatsdClient($sender);
-// $client = new PacketReducer($client); // if you want to compose socket packets with multi metric
-
-$factory = new StatsdDataFactory();
-
-$logger = new Logger('my_logger');
-$logger->pushHandler(new StatsDHandler($client, $factory, 'prefix', Logger::DEBUG));
-
-$logger->addInfo('My logger is now ready');
-```
-
-the output will be:  `prefix.my_logger.INFO.My-logger:1|c" 36 Bytes`
-
+please have a look to [example with monolog.php](src/example/monolog.php)
 
 ## Short Theory
 
 ### Easily Install StatsD and Graphite
 
-In order to try this application monitor you have to install etsy/statsd and Graphite
-
-see this blog post to install it with vagrant [Easy install statsd graphite](http://welcometothebundle.com/easily-install-statsd-and-graphite-with-vagrant/).
+There are a lot of resources on internet on how to install etsy/statsd and Graphite,
+eg. [Easy install statsd graphite](http://welcometothebundle.com/easily-install-statsd-and-graphite-with-vagrant/).
 
 #### [StatsD](https://github.com/etsy/statsd)
 
@@ -153,8 +136,10 @@ phpunit --coverage-html reports
   * The StatsdClientInterface::MAX_UDP_SIZE_STR is deprecated.
   * The StastdClient::constructor permit only to parameters not 3, the boolean packet reducer has been removed,
     in favour of the PacketReducer Class that act as decorator.
-  * The methods of StastdClient are not public
+  * The methods of StastdClient are not public anymore:
      - setFailSilently
      - getFailSilently
      - setSender
      - getSender
+  * The Factory\StatsdDataFactoryInterface::produceStatsdData has been removed
+  * The Factory\StatsdDataFactory::produceStatsdData has been marked as protected

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 ## statsd-php-client
 
-Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there's a BC.
+Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there's a BC, and for  1.0.*
 
 [![Build Status](https://secure.travis-ci.org/liuggio/statsd-php-client.png)](http://travis-ci.org/liuggio/statsd-php-client) [![Latest Stable Version](https://poser.pugx.org/liuggio/statsd-php-client/v/stable.png)](https://packagist.org/packages/liuggio/statsd-php-client) [![Total Downloads](https://poser.pugx.org/liuggio/statsd-php-client/downloads.png)](https://packagist.org/packages/liuggio/statsd-php-client)
 
@@ -16,7 +16,7 @@ Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there'
 
 - You are wise.
 
-- You could also use monolog to redirect data to statsd
+- You could also use monolog to redirect data to StatsD
 
 - This library is tested.
 
@@ -35,11 +35,13 @@ Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there'
 
 2. create the Client
 
-3. create the Factory
+3. optional - decorate the client with the PacketReducer
 
-4. the Factory will help you to create data
+4. create the Factory
 
-5. the Client will send the data
+5. the Factory will help you to create data
+
+6. the Client will send the data
 
 ### Standard Usage
 
@@ -47,12 +49,15 @@ Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there'
 use Liuggio\StatsdClient\StatsdClient,
     Liuggio\StatsdClient\Factory\StatsdDataFactory,
     Liuggio\StatsdClient\Sender\SocketSender;
+// use Liuggio\StatsdClient\PacketReducer;
 // use Liuggio\StatsdClient\Sender\SysLogSender;
 
 $sender = new SocketSender(/*'localhost', 8126, 'udp'*/);
 // $sender = new SysLogSender(); // enabling this, the packet will not send over the socket
 
 $client = new StatsdClient($sender);
+// $client = new PacketReducer($client); // if you want to compose socket packets with multi metric
+
 $factory = new StatsdDataFactory('\Liuggio\StatsdClient\Entity\StatsdData');
 
 // create the data with the factory
@@ -72,6 +77,7 @@ $client->send($data);
 use Liuggio\StatsdClient\StatsdClient,
     Liuggio\StatsdClient\Factory\StatsdDataFactory,
     Liuggio\StatsdClient\Sender\SocketSender;
+// use Liuggio\StatsdClient\PacketReducer;
 // use Liuggio\StatsdClient\Sender\SysLogSender;
 
 use Monolog\Logger;
@@ -80,6 +86,8 @@ use Liuggio\StatsdClient\Monolog\Handler\StatsDHandler;
 $sender = new SocketSender(/*'localhost', 8126, 'udp'*/);
 // $sender = new SysLogSender(); // enabling this, the packet will not send over the socket
 $client = new StatsdClient($sender);
+// $client = new PacketReducer($client); // if you want to compose socket packets with multi metric
+
 $factory = new StatsdDataFactory();
 
 $logger = new Logger('my_logger');
@@ -91,11 +99,9 @@ $logger->addInfo('My logger is now ready');
 the output will be:  `prefix.my_logger.INFO.My-logger:1|c" 36 Bytes`
 
 
-
-
 ## Short Theory
 
-### Easily Install StatSD and Graphite
+### Easily Install StatsD and Graphite
 
 In order to try this application monitor you have to install etsy/statsd and Graphite
 
@@ -139,11 +145,16 @@ composer.phar install
 phpunit --coverage-html reports
 ```
 
-## Upgrade
+## Upgrading
 
-BC from the v1.0.4 version, [see Sender and Client differences](https://github.com/liuggio/statsd-php-client/pull/5/files).
+- BC from the v1.0.4 version, [see Sender and Client differences](https://github.com/liuggio/statsd-php-client/pull/5/files).
 
-
-## TODO
-
-example with monolog
+- BC from the v1.0.* version:
+  * The StatsdClientInterface::MAX_UDP_SIZE_STR is deprecated.
+  * The StastdClient::constructor permit only to parameters not 3, the boolean packet reducer has been removed,
+    in favour of the PacketReducer Class that act as decorator.
+  * The methods of StastdClient are not public
+     - setFailSilently
+     - getFailSilently
+     - setSender
+     - getSender

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,10 @@
     },
     "suggest": {
         "monolog/monolog": "Monolog, in order to do generate statistic from log >=1.2.0)"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.x-dev"
+        }
     }
 }

--- a/example/example.php
+++ b/example/example.php
@@ -56,4 +56,3 @@ $sendHandler->gauge('gaugor', 333);
 $sendHandler->set('uniques', 765);
 // $sendHandler->send(); this function doesn't do anything.
 echo "----------------".PHP_EOL;
-echo "closing";

--- a/example/example.php
+++ b/example/example.php
@@ -1,0 +1,59 @@
+<?php
+
+require_once __DIR__ . "/../vendor/autoload.php";
+
+use Liuggio\StatsdClient\Factory\StatsdDataFactory;
+use Liuggio\StatsdClient\Sender\EchoSender;
+//use Liuggio\StatsdClient\Sender\SocketSender;
+use Liuggio\StatsdClient\StatsdClient;
+use Liuggio\StatsdClient\PacketReducer;
+
+use Liuggio\StatsdClient\Handler\BufferHandler;
+use Liuggio\StatsdClient\Handler\SendHandler;
+
+// new sender dumping to the standard output.
+$sender = new EchoSender();
+//$sender = SocketSender('localhost', 8126) // new sender using socket.
+
+$client = new StatsdClient($sender);
+// add decorator to reduce packets.
+$client = new PacketReducer($client);
+$factory = new StatsdDataFactory('\Liuggio\StatsdClient\Entity\StatsdData');
+
+echo "Sending using only the client:".PHP_EOL;
+$data[] = "increment:1|c";
+$data[] = "set:value|s";
+$data[] = "gauge:value|g";
+$data[] = "timing:10|ms";
+$data[] = "decrement:-1|c";
+$data[] = "key:1|c";
+$client->send($data);
+echo "----------------".PHP_EOL;
+
+echo "Using the Factory and sending with the Client:".PHP_EOL;
+$data[] = $factory->increment(1);
+$client->send($data);
+echo "----------------".PHP_EOL;
+
+echo "Using BufferHandler:".PHP_EOL;
+// the handler will collect the data until a `$bufferHandler->send()` or `$bufferHandler->close()`.
+$bufferHandler = new BufferHandler($client, $factory);
+$bufferHandler->timing('usageTime', 100);
+$bufferHandler->increment('visitor');
+$bufferHandler->decrement('click');
+$bufferHandler->gauge('gaugor', 333);
+$bufferHandler->set('uniques', 765);
+$bufferHandler->send();
+echo "----------------".PHP_EOL;
+
+echo "Using SendHandler:".PHP_EOL;
+// the handler will send immediately the data.
+$sendHandler = new SendHandler($client, $factory);
+$sendHandler->timing('usageTime', 100);
+$sendHandler->increment('visitor');
+$sendHandler->decrement('click');
+$sendHandler->gauge('gaugor', 333);
+$sendHandler->set('uniques', 765);
+// $sendHandler->send(); this function doesn't do anything.
+echo "----------------".PHP_EOL;
+echo "closing";

--- a/example/monolog.php
+++ b/example/monolog.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once __DIR__ . "/../vendor/autoload.php";
+
+use Liuggio\StatsdClient\Factory\StatsdDataFactory;
+use Liuggio\StatsdClient\Sender\EchoSender;
+//use Liuggio\StatsdClient\Sender\SocketSender;
+use Liuggio\StatsdClient\StatsdClient;
+use Liuggio\StatsdClient\PacketReducer;
+use Monolog\Logger;
+use Liuggio\StatsdClient\Monolog\Handler\StatsDHandler;
+
+// new sender dumping to the standard output.
+$sender = new EchoSender();
+//$sender = SocketSender('localhost', 8126) // new sender using socket.
+$client = new StatsdClient($sender);
+// add decorator to reduce packets.
+$client = new PacketReducer($client);
+$factory = new StatsdDataFactory('\Liuggio\StatsdClient\Entity\StatsdData');
+
+echo "Using monolog to send data to statsd:".PHP_EOL;
+// Create the logger
+$logger = new Logger('my_logger');
+// Now add StatsD monolog-handler
+$logger->pushHandler(new StatsDHandler($client, $factory, 'prefix', Logger::DEBUG));
+// You can now use your logger
+$logger->addInfo('My logger is now ready');

--- a/src/Liuggio/StatsdClient/Entity/StatsdData.php
+++ b/src/Liuggio/StatsdClient/Entity/StatsdData.php
@@ -6,7 +6,6 @@ use Liuggio\StatsdClient\Entity\StatsdDataInterface;
 
 class StatsdData implements StatsdDataInterface
 {
-
     private $key;
     private $value;
     private $metric;
@@ -42,7 +41,6 @@ class StatsdData implements StatsdDataInterface
     {
         return $this->value;
     }
-
 
     public function setMetric($metric)
     {

--- a/src/Liuggio/StatsdClient/Entity/StatsdDataInterface.php
+++ b/src/Liuggio/StatsdClient/Entity/StatsdDataInterface.php
@@ -13,29 +13,29 @@ interface StatsdDataInterface
      * @abstract
      * @return string
      */
-    function getKey();
+    public function getKey();
 
     /**
      * @abstract
      * @return mixed
      */
-    function getValue();
+    public function getValue();
 
     /**
      * @abstract
      * @return string
      */
-    function getMetric();
+    public function getMetric();
 
     /**
      * @abstract
      * @return string
      */
-    function getMessage();
+    public function getMessage();
 
     /**
      * @abstract
      * @return string
      */
-    function __toString();
+    public function __toString();
 }

--- a/src/Liuggio/StatsdClient/Factory/StatsdDataFactory.php
+++ b/src/Liuggio/StatsdClient/Factory/StatsdDataFactory.php
@@ -59,28 +59,6 @@ class StatsdDataFactory implements StatsdDataFactoryInterface
     /**
      * {@inheritDoc}
      **/
-    public function produceStatsdData($key, $value = 1, $metric = StatsdDataInterface::STATSD_METRIC_COUNT)
-    {
-        $statsdData = $this->produceStatsdDataEntity();
-
-        if (null !== $key) {
-            $statsdData->setKey($key);
-        }
-
-        if (null !== $value) {
-            $statsdData->setValue($value);
-        }
-
-        if (null !== $metric) {
-            $statsdData->setMetric($metric);
-        }
-
-        return $statsdData;
-    }
-
-    /**
-     * {@inheritDoc}
-     **/
     public function produceStatsdDataEntity()
     {
         $statsdData = $this->getEntityClass();
@@ -118,5 +96,24 @@ class StatsdDataFactory implements StatsdDataFactoryInterface
     public function getEntityClass()
     {
         return $this->entityClass;
+    }
+
+    private function produceStatsdData($key, $value = 1, $metric = StatsdDataInterface::STATSD_METRIC_COUNT)
+    {
+        $statsdData = $this->produceStatsdDataEntity();
+
+        if (null !== $key) {
+            $statsdData->setKey($key);
+        }
+
+        if (null !== $value) {
+            $statsdData->setValue($value);
+        }
+
+        if (null !== $metric) {
+            $statsdData->setMetric($metric);
+        }
+
+        return $statsdData;
     }
 }

--- a/src/Liuggio/StatsdClient/Factory/StatsdDataFactory.php
+++ b/src/Liuggio/StatsdClient/Factory/StatsdDataFactory.php
@@ -98,7 +98,7 @@ class StatsdDataFactory implements StatsdDataFactoryInterface
         return $this->entityClass;
     }
 
-    private function produceStatsdData($key, $value = 1, $metric = StatsdDataInterface::STATSD_METRIC_COUNT)
+    protected function produceStatsdData($key, $value = 1, $metric = StatsdDataInterface::STATSD_METRIC_COUNT)
     {
         $statsdData = $this->produceStatsdDataEntity();
 

--- a/src/Liuggio/StatsdClient/Factory/StatsdDataFactoryInterface.php
+++ b/src/Liuggio/StatsdClient/Factory/StatsdDataFactoryInterface.php
@@ -38,8 +38,8 @@ Interface StatsdDataFactoryInterface
      *
      * @abstract
      *
-     * @param string|array $key   The metric(s) to set.
-     * @param float        $value The value for the stats.
+     * @param  string|array $key   The metric(s) to set.
+     * @param  float        $value The value for the stats.
      *
      * @return array
      **/
@@ -68,5 +68,4 @@ Interface StatsdDataFactoryInterface
      * @return mixed
      **/
     public function decrement($key);
-
 }

--- a/src/Liuggio/StatsdClient/Factory/StatsdDataFactoryInterface.php
+++ b/src/Liuggio/StatsdClient/Factory/StatsdDataFactoryInterface.php
@@ -2,33 +2,30 @@
 
 namespace Liuggio\StatsdClient\Factory;
 
-use Liuggio\StatsdClient\Entity\StatsdDataInterface;
-
 Interface StatsdDataFactoryInterface
 {
-
     /**
-     * This function creates a 'timing' StatsdData.
+     * This public function creates a 'timing' StatsdData.
      *
      * @abstract
      *
      * @param string|array $key  The metric(s) to set.
      * @param float        $time The elapsed time (ms) to log
      **/
-    function timing($key, $time);
+    public function timing($key, $time);
 
     /**
-     * This function creates a 'gauge' StatsdData.
+     * This public function creates a 'gauge' StatsdData.
      *
      * @abstract
      *
      * @param string|array $key   The metric(s) to set.
      * @param float        $value The value for the stats.
      **/
-    function gauge($key, $value);
+    public function gauge($key, $value);
 
     /**
-     * This function creates a 'set' StatsdData object
+     * This public function creates a 'set' StatsdData object
      * A "Set" is a count of unique events.
      * This data type acts like a counter, but supports counting
      * of unique occurrences of values between flushes. The backend
@@ -41,15 +38,15 @@ Interface StatsdDataFactoryInterface
      *
      * @abstract
      *
-     * @param  string|array $key   The metric(s) to set.
-     * @param  float        $value The value for the stats.
+     * @param string|array $key   The metric(s) to set.
+     * @param float        $value The value for the stats.
      *
      * @return array
      **/
-    function set($key, $value);
+    public function set($key, $value);
 
     /**
-     * This function creates a 'increment' StatsdData object.
+     * This public function creates a 'increment' StatsdData object.
      *
      * @abstract
      *
@@ -58,10 +55,10 @@ Interface StatsdDataFactoryInterface
      *
      * @return array
      **/
-    function increment($key);
+    public function increment($key);
 
     /**
-     * This function creates a 'decrement' StatsdData object.
+     * This public function creates a 'decrement' StatsdData object.
      *
      * @abstract
      *
@@ -70,18 +67,6 @@ Interface StatsdDataFactoryInterface
      *
      * @return mixed
      **/
-    function decrement($key);
+    public function decrement($key);
 
-    /**
-     * Produce a StatsdDataInterface Object.
-     *
-     * @abstract
-     *
-     * @param string $key    The key of the metric
-     * @param int    $value  The amount to increment/decrement each metric by.
-     * @param string $metric The metric type ("c" for count, "ms" for timing, "g" for gauge, "s" for set)
-     *
-     * @return StatsdDataInterface
-     **/
-    function produceStatsdData($key, $value = 1, $metric = StatsdDataInterface::STATSD_METRIC_COUNT);
 }

--- a/src/Liuggio/StatsdClient/Handler/BufferHandler.php
+++ b/src/Liuggio/StatsdClient/Handler/BufferHandler.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Liuggio\StatsdClient\Handler;
+
+use Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface;
+use Liuggio\StatsdClient\StatsdClientInterface;
+
+/**
+ * This Handler put all the data in a buffer until a send or close is called.
+ */
+class BufferHandler implements StatsdDataFactoryInterface, HandlerInterface
+{
+    private $factory;
+    private $client;
+    private $buffer;
+
+    /**
+     * @param StatsdClientInterface      $client
+     * @param StatsdDataFactoryInterface $factory
+     */
+    public function __construct(StatsdClientInterface $client, StatsdDataFactoryInterface $factory)
+    {
+        $this->client = $client;
+        $this->factory = $factory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send()
+    {
+        return $this->client->send($this->popBuffer());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close()
+    {
+        return $this->send();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function timing($key, $time)
+    {
+        $this->addToBuffer($this->factory->timing($key, $time));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function gauge($key, $value)
+    {
+        $this->addToBuffer($this->factory->gauge($key, $value));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function set($key, $value)
+    {
+        $this->addToBuffer($this->factory->set($key, $value));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function increment($key)
+    {
+        $this->addToBuffer($this->factory->increment($key));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function decrement($key)
+    {
+        $this->addToBuffer($this->factory->decrement($key));
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->close();
+        } catch (\Exception $e) {
+            // do nothing
+        }
+    }
+
+    private function addToBuffer($data)
+    {
+        $this->buffer[] = $data;
+    }
+
+    private function popBuffer()
+    {
+        $buffer = $this->buffer;
+        $this->buffer = array();
+
+        return $buffer;
+    }
+}

--- a/src/Liuggio/StatsdClient/Handler/HandlerInterface.php
+++ b/src/Liuggio/StatsdClient/Handler/HandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Liuggio\StatsdClient\Handler;
+
+interface HandlerInterface
+{
+    public function send();
+
+    public function close();
+
+}

--- a/src/Liuggio/StatsdClient/Handler/SendHandler.php
+++ b/src/Liuggio/StatsdClient/Handler/SendHandler.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Liuggio\StatsdClient\Handler;
+
+use Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface;
+use Liuggio\StatsdClient\StatsdClientInterface;
+
+/**
+ * Class SendHandler
+ * This Handler send over the client the packet.
+ */
+class SendHandler implements StatsdDataFactoryInterface, HandlerInterface
+{
+    private $factory;
+    private $client;
+
+    /**
+     * @param StatsdClientInterface      $client
+     * @param StatsdDataFactoryInterface $factory
+     */
+    public function __construct(StatsdClientInterface $client, StatsdDataFactoryInterface $factory)
+    {
+        $this->client = $client;
+        $this->factory = $factory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function timing($key, $time)
+    {
+        $this->client->send($this->factory->timing($key, $time));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function gauge($key, $value)
+    {
+        $this->client->send($this->factory->gauge($key, $value));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function set($key, $value)
+    {
+        $this->client->send($this->factory->set($key, $value));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function increment($key)
+    {
+        $this->client->send($this->factory->increment($key));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function decrement($key)
+    {
+        $this->client->send($this->factory->decrement($key));
+    }
+}

--- a/src/Liuggio/StatsdClient/Monolog/Formatter/StatsDFormatter.php
+++ b/src/Liuggio/StatsdClient/Monolog/Formatter/StatsDFormatter.php
@@ -22,9 +22,9 @@ class StatsDFormatter extends LineFormatter
     protected $logExtra;
 
     /**
-     * @param string $format The format of the message
-     * @param Boolean $logContext If true add multiple rows containing Context information
-     * @param Boolean $logExtra If true add multiple rows containing Extra information
+     * @param string  $format        The format of the message
+     * @param Boolean $logContext    If true add multiple rows containing Context information
+     * @param Boolean $logExtra      If true add multiple rows containing Extra information
      * @param integer $numberOfWords The number of words to show.
      */
     public function __construct($format = null, $logContext = true, $logExtra = true, $numberOfWords = 2)

--- a/src/Liuggio/StatsdClient/Monolog/Handler/StatsDHandler.php
+++ b/src/Liuggio/StatsdClient/Monolog/Handler/StatsDHandler.php
@@ -39,11 +39,11 @@ class StatsDHandler extends AbstractProcessingHandler
     protected $statsDFactory;
 
     /**
-     * @param StatsdClientInterface $statsDService The Service sends the packet
+     * @param StatsdClientInterface      $statsDService The Service sends the packet
      * @param StatsdDataFactoryInterface $statsDFactory The Factory creates the StatsDPacket
-     * @param string $prefix Statsd key prefix
-     * @param integer $level The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param string                     $prefix        Statsd key prefix
+     * @param integer                    $level         The minimum logging level at which this handler will be triggered
+     * @param Boolean                    $bubble        Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(StatsdClientInterface $statsDService, StatsdDataFactoryInterface $statsDFactory = null, $prefix, $level = Logger::DEBUG, $bubble = true)
     {

--- a/src/Liuggio/StatsdClient/PacketReducer.php
+++ b/src/Liuggio/StatsdClient/PacketReducer.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Liuggio\StatsdClient;
+
+use Liuggio\StatsdClient\StatsdClientInterface;
+use Liuggio\StatsdClient\Entity\StatsdDataInterface;
+
+/**
+ * This is a decorator the StatsdClientInterface
+ * Class Reducer
+ *
+ * @package Liuggio\StatsdClient\Reducer
+ */
+class PacketReducer implements StatsdClientInterface
+{
+    /**
+     * Jumbo frames can make use of this feature much more efficient.
+     */
+    const MAX_UDP_SIZE_GIGABIT = 8932;
+    /**
+     *  This is most likely for Intranets.
+     */
+    const MAX_UDP_SIZE_INTRANET = 1432;
+    /**
+     * If you are routing over the internet a value
+     * in this range will be reasonable.
+     * You might be able to go higher,
+     * but you are at the mercy of all the hops in your route.
+     */
+    const MAX_UDP_SIZE_COMMODITY = 512;
+
+    /**
+     * @var StatsdClientInterface
+     */
+    private $client;
+
+    /**
+     * @var int
+     */
+    private static $packetSize = self::MAX_UDP_SIZE_COMMODITY;
+
+    public function __construct(StatsdClientInterface $client, $packetSize = self::MAX_UDP_SIZE_COMMODITY)
+    {
+        $this->client = $client;
+        self::$packetSize = $packetSize;
+    }
+
+    /**
+     * This function reduces the number of packets,the reduced has the maximum dimension of self::MAX_UDP_SIZE_STR
+     * Reference:
+     * https://github.com/etsy/statsd/blob/master/README.md
+     * All metrics can also be batch send in a single UDP packet, separated by a newline character.
+     *
+     * @param array $reducedMetrics
+     * @param array $metric
+     *
+     * @return array
+     */
+    private static function doReduce($reducedMetrics, $metric)
+    {
+        $metricLength = strlen($metric);
+        $lastReducedMetric = count($reducedMetrics) > 0 ? end($reducedMetrics) : null;
+
+        if ($metricLength >= self::$packetSize
+            || null === $lastReducedMetric
+            || strlen($newMetric = $lastReducedMetric . "\n" . $metric) > self::$packetSize
+        ) {
+            $reducedMetrics[] = $metric;
+        } else {
+            array_pop($reducedMetrics);
+            $reducedMetrics[] = $newMetric;
+        }
+
+        return $reducedMetrics;
+    }
+
+    /*
+    * Send the metrics over the socket.
+    *
+    * {@inheritDoc}
+    */
+    public function send($data, $sampleRate = 1)
+    {
+        if (null===$data || (is_array($data) && count($data)==0)) {
+            return 0;
+        }
+
+        $data = $this->normalizeData($data);
+        if (is_array($data)) {
+            $data = array_reduce($data, "self::doReduce", array());
+        }
+
+        return $this->client->send($data, $sampleRate);
+    }
+
+    /**
+     * Transform all the data given into an array.
+     *
+     * @param $data
+     *
+     * @return array
+     */
+    private function normalizeData($data)
+    {
+        // check format
+        if ($data instanceof StatsdDataInterface || is_string($data)) {
+            return array($data);
+        }
+        if (is_array($data) && !empty($data)) {
+            return $data;
+        }
+
+        return null;
+    }
+}

--- a/src/Liuggio/StatsdClient/Sender/EchoSender.php
+++ b/src/Liuggio/StatsdClient/Sender/EchoSender.php
@@ -2,7 +2,6 @@
 
 namespace Liuggio\StatsdClient\Sender;
 
-
 Class EchoSender implements SenderInterface
 {
     /**
@@ -10,7 +9,7 @@ Class EchoSender implements SenderInterface
      */
     public function open()
     {
-        echo "[open]";
+        echo "[open]".PHP_EOL;
 
         return true;
     }
@@ -18,9 +17,9 @@ Class EchoSender implements SenderInterface
     /**
      * {@inheritDoc}
      */
-    function write($handle, $message, $length = null)
+    public function write($handle, $message, $length = null)
     {
-        echo "[$message]";
+        echo "[$message]".PHP_EOL;
 
         return strlen($message);
     }
@@ -28,8 +27,8 @@ Class EchoSender implements SenderInterface
     /**
      * {@inheritDoc}
      */
-    function close($handle)
+    public function close($handle)
     {
-        echo "[closed]";
+        echo "[closed]".PHP_EOL;
     }
 }

--- a/src/Liuggio/StatsdClient/Sender/SenderInterface.php
+++ b/src/Liuggio/StatsdClient/Sender/SenderInterface.php
@@ -5,13 +5,12 @@ namespace Liuggio\StatsdClient\Sender;
 Interface SenderInterface
 {
     /**
-     * @abstract
+     *
      * @return mixed
      */
-    function open();
+    public function open();
 
     /**
-     * @abstract
      *
      * @param        $handle
      * @param string $string
@@ -19,14 +18,13 @@ Interface SenderInterface
      *
      * @return mixed
      */
-    function write($handle, $string, $length = null);
+    public function write($handle, $string, $length = null);
 
     /**
-     * @abstract
      *
      * @param $handle
      *
      * @return mixed
      */
-    function close($handle);
+    public function close($handle);
 }

--- a/src/Liuggio/StatsdClient/Sender/SocketSender.php
+++ b/src/Liuggio/StatsdClient/Sender/SocketSender.php
@@ -55,7 +55,6 @@ Class SocketSender implements SenderInterface
         socket_close($handle);
     }
 
-
     protected function setHost($host)
     {
         $this->host = $host;

--- a/src/Liuggio/StatsdClient/Sender/SysLogSender.php
+++ b/src/Liuggio/StatsdClient/Sender/SysLogSender.php
@@ -2,7 +2,6 @@
 
 namespace Liuggio\StatsdClient\Sender;
 
-
 Class SysLogSender implements SenderInterface
 {
     private $priority;
@@ -25,7 +24,7 @@ Class SysLogSender implements SenderInterface
     /**
      * {@inheritDoc}
      */
-    function write($handle, $message, $length = null)
+    public function write($handle, $message, $length = null)
     {
         syslog($this->priority, sprintf("statsd-client-write \"%s\" %d Bytes", $message, strlen($message)));
 
@@ -35,7 +34,7 @@ Class SysLogSender implements SenderInterface
     /**
      * {@inheritDoc}
      */
-    function close($handle)
+    public function close($handle)
     {
         syslog($this->priority, "statsd-client-close");
     }

--- a/src/Liuggio/StatsdClient/StatsdClient.php
+++ b/src/Liuggio/StatsdClient/StatsdClient.php
@@ -4,7 +4,6 @@ namespace Liuggio\StatsdClient;
 
 use Liuggio\StatsdClient\Sender\SenderInterface;
 use Liuggio\StatsdClient\Entity\StatsdDataInterface;
-use Liuggio\StatsdClient\Exception\InvalidArgumentException;
 
 class StatsdClient implements StatsdClientInterface
 {
@@ -14,133 +13,38 @@ class StatsdClient implements StatsdClientInterface
     private $failSilently;
 
     /**
-     * @var \Liuggio\StatsdClient\Sender\SenderInterface
+     * @var SenderInterface
      */
     private $sender;
 
     /**
-     * @var boolean
-     */
-    private $reducePacket;
-
-    /**
      * Constructor.
      *
-     * @param \Liuggio\StatsdClient\Sender\SenderInterface $sender
-     * @param Boolean                                      $reducePacket
-     * @param Boolean                                      $fail_silently
+     * @param SenderInterface $sender
+     * @param boolean         $fail_silently
      */
-    public function __construct(SenderInterface $sender, $reducePacket = true, $fail_silently = true)
+    public function __construct(SenderInterface $sender, $fail_silently = true)
     {
         $this->sender       = $sender;
-        $this->reducePacket = $reducePacket;
         $this->failSilently = $fail_silently;
     }
 
-    /**
-     * Throws an exc only if failSilently if  getFailSilently is false.
-     *
-     * @param \Exception $exception
-     *
-     * @throws \Exception
-     */
-    private function throwException(\Exception $exception)
-    {
-        if (!$this->getFailSilently()) {
-            throw $exception;
-        }
-    }
-
-    /**
-     * This function reduces the number of packets,the reduced has the maximum dimension of self::MAX_UDP_SIZE_STR
-     * Reference:
-     * https://github.com/etsy/statsd/blob/master/README.md
-     * All metrics can also be batch send in a single UDP packet, separated by a newline character.
-     *
-     * @param array $reducedMetrics
-     * @param array $metric
-     *
-     * @return array
-     */
-    private static function doReduce($reducedMetrics, $metric)
-    {
-        $metricLength = strlen($metric);
-        $lastReducedMetric = count($reducedMetrics) > 0 ? end($reducedMetrics) : null;
-
-        if ($metricLength >= self::MAX_UDP_SIZE_STR
-            || null === $lastReducedMetric
-            || strlen($newMetric = $lastReducedMetric . "\n" . $metric) > self::MAX_UDP_SIZE_STR
-        ) {
-            $reducedMetrics[] = $metric;
-        } else {
-            array_pop($reducedMetrics);
-            $reducedMetrics[] = $newMetric;
-        }
-
-        return $reducedMetrics;
-    }
-
-
-    /**
-     * this function reduce the amount of data that should be send
-     *
-     * @param mixed $arrayData
-     *
-     * @return mixed $arrayData
-     */
-    public function reduceCount($arrayData)
-    {
-        if (is_array($arrayData)) {
-            $arrayData = array_reduce($arrayData, "self::doReduce", array());
-        }
-
-        return $arrayData;
-    }
-
-    /**
-     *  Reference: https://github.com/etsy/statsd/blob/master/README.md
-     *  Sampling 0.1
-     *  Tells StatsD that this counter is being sent sampled every 1/10th of the time.
-     *
-     * @param mixed $data
-     * @param int   $sampleRate
-     *
-     * @return mixed $data
-     */
-    public function appendSampleRate($data, $sampleRate = 1)
-    {
-        $sampledData = array();
-        if ($sampleRate < 1) {
-            foreach ($data as $key => $message) {
-                $sampledData[$key] = sprintf('%s|@%s', $message, $sampleRate);
-            }
-            $data = $sampledData;
-        }
-
-        return $data;
-    }
-
     /*
-     * Send the metrics over UDP
+     * Send the metrics over the socket.
      *
      * {@inheritDoc}
      */
     public function send($data, $sampleRate = 1)
     {
-        // check format
-        if ($data instanceof StatsdDataInterface || is_string($data)) {
-            $data = array($data);
+        if (null===$data || (is_array($data) && count($data)==0)) {
+            return 0;
         }
-        if (!is_array($data) || empty($data)) {
-            return;
-        }
+
+        $data = $this->normalizeData($data);
+
         // add sampling
         if ($sampleRate < 1) {
             $data = $this->appendSampleRate($data, $sampleRate);
-        }
-        // reduce number of packets
-        if ($this->getReducePacket()) {
-            $data = $this->reduceCount($data);
         }
         //failures in any of this should be silently ignored if ..
         try {
@@ -171,41 +75,73 @@ class StatsdClient implements StatsdClientInterface
     /**
      * @return boolean
      */
-    public function getFailSilently()
+    private function getFailSilently()
     {
         return $this->failSilently;
     }
 
     /**
-     * @param \Liuggio\StatsdClient\Sender\SenderInterface $sender
+     * @return SenderInterface
      */
-    public function setSender(SenderInterface $sender)
-    {
-        $this->sender = $sender;
-    }
-
-    /**
-     * @return \Liuggio\StatsdClient\Sender\SenderInterface
-     */
-    public function getSender()
+    private function getSender()
     {
         return $this->sender;
     }
 
     /**
-     * @param boolean $reducePacket
+     *  Reference: https://github.com/etsy/statsd/blob/master/README.md
+     *  Sampling 0.1
+     *  Tells StatsD that this counter is being sent sampled every 1/10th of the time.
+     *
+     * @param     $data
+     * @param int $sampleRate
+     *
+     * @return array
      */
-    public function setReducePacket($reducePacket)
+    private function appendSampleRate($data, $sampleRate = 1)
     {
-        $this->reducePacket = $reducePacket;
+        $sampledData = array();
+        if ($sampleRate < 1) {
+            foreach ($data as $key => $message) {
+                $sampledData[$key] = sprintf('%s|@%s' . $message . $sampleRate);
+            }
+            $data = $sampledData;
+        }
+
+        return $data;
     }
 
     /**
-     * @return boolean
+     * Transform all the data given into an array.
+     *
+     * @param $data
+     *
+     * @return array
      */
-    public function getReducePacket()
+    private function normalizeData($data)
     {
-        return $this->reducePacket;
+        // check format
+        if ($data instanceof StatsdDataInterface || is_string($data)) {
+            return array($data);
+        }
+        if (is_array($data) && !empty($data)) {
+            return $data;
+        }
+
+        return null;
     }
 
+    /**
+     * Throws an exception only if failSilently is false.
+     *
+     * @param \Exception $exception
+     *
+     * @throws \Exception
+     */
+    private function throwException(\Exception $exception)
+    {
+        if (!$this->getFailSilently()) {
+            throw $exception;
+        }
+    }
 }

--- a/src/Liuggio/StatsdClient/StatsdClientInterface.php
+++ b/src/Liuggio/StatsdClient/StatsdClientInterface.php
@@ -2,22 +2,21 @@
 
 namespace Liuggio\StatsdClient;
 
-use Liuggio\StatsdClient\Sender\SenderInterface;
-use Liuggio\StatsdClient\Entity\StatsdDataInterface;
-use Liuggio\StatsdClient\Exception\InvalidArgumentException;
-
 Interface StatsdClientInterface
 {
+    /**
+     * @deprecated see PacketReducer constant
+     */
     const MAX_UDP_SIZE_STR = 512;
 
     /*
-     * Send the metrics over UDP
+     * Send the metrics
      *
      * @abstract
-     * @param array|string|StatsdDataInterface  $data message(s) to sent
-     * @param int $sampleRate Tells StatsD that this counter is being sent sampled every Xth of the time.
+     * @param array|string|\Liuggio\StatsdClient\Sender\StatsdDataInterface $data       message(s) to sent
+     * @param int                                                           $sampleRate Tells StatsD that this counter is being sent sampled every Xth of the time.
      *
      * @return integer the data sent in bytes
      */
-    function send($data, $sampleRate = 1);
+    public function send($data, $sampleRate = 1);
 }

--- a/tests/Liuggio/StatsdClient/Entity/StatsdDataTest.php
+++ b/tests/Liuggio/StatsdClient/Entity/StatsdDataTest.php
@@ -4,7 +4,6 @@ namespace Liuggio\StatsdClient\Entity;
 
 use Liuggio\StatsdClient\Entity\StatsdData;
 
-
 class StatsdDataTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetMessage()

--- a/tests/Liuggio/StatsdClient/Factory/StatsdDataFactoryTest.php
+++ b/tests/Liuggio/StatsdClient/Factory/StatsdDataFactoryTest.php
@@ -13,16 +13,6 @@ class StatsDataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->statsDataFactory = new StatsdDataFactory('\Liuggio\StatsdClient\Entity\StatsdData');
     }
 
-    public function testProduceStatsdData()
-    {
-        $key = 'key';
-        $value='val';
-
-        $obj = $this->statsDataFactory->produceStatsdData($key, $value);
-        $this->assertEquals($key, $obj->getKey());
-        $this->assertEquals($value, $obj->getValue());
-    }
-
     public function testTiming()
     {
         $key = 'key';
@@ -35,13 +25,13 @@ class StatsDataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('ms', $obj->getMetric());
     }
 
-    public function testProduceStatsdDataDecrement()
+    public function testDecrement()
     {
         $key = 'key';
         $value = -1;
         $stringValue = intval($value);
 
-        $obj = $this->statsDataFactory->produceStatsdData($key, $value);
+        $obj = $this->statsDataFactory->decrement($key);
         $this->assertEquals($key, $obj->getKey());
         $this->assertEquals($stringValue, $obj->getValue());
         $this->assertEquals('c', $obj->getMetric());
@@ -59,19 +49,7 @@ class StatsDataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('g', $obj->getMetric());
     }
 
-    public function testDecrement()
-    {
-        $key = 'key';
-        $value = -1;
-        $stringValue = intval($value);
-
-        $obj = $this->statsDataFactory->decrement($key);
-        $this->assertEquals($key, $obj->getKey());
-        $this->assertEquals($stringValue, $obj->getValue());
-        $this->assertEquals('c', $obj->getMetric());
-    }
-
-    public function testcreateStatsdDataIncrement()
+    public function testIncrement()
     {
         $key = 'key';
         $value = 1;

--- a/tests/Liuggio/StatsdClient/Handler/BufferHandlerTest.php
+++ b/tests/Liuggio/StatsdClient/Handler/BufferHandlerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Liuggio\StatsdClient;
+
+use Liuggio\StatsdClient\Handler\BufferHandler;
+
+class BufferHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOnCloseShouldEmptyTheBuffer()
+    {
+        $client = $this->getMock('\Liuggio\StatsdClient\StatsdClientInterface');
+        $factory = $this->getMock('\Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface');
+        $bufferHandler = new BufferHandler($client, $factory);
+
+        $key = 'key';
+        $data = array($key=>'1');
+
+        $factory->expects($this->once())
+            ->method('increment')
+            ->with($this->equalTo($key))
+            ->will($this->returnValue($data));
+
+        $bufferHandler->increment($key);
+
+        $client->expects($this->at(0))
+            ->method('send')
+            ->with($this->equalTo(array($data)));
+        $bufferHandler->send();
+
+        $client->expects($this->at(1))
+            ->method('send')
+            ->with($this->equalTo(array()));
+
+        $bufferHandler->close();
+    }
+
+    public function testOnSendShouldEmptyTheBuffer()
+    {
+        $client = $this->getMock('\Liuggio\StatsdClient\StatsdClientInterface');
+        $factory = $this->getMock('\Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface');
+        $bufferHandler = new BufferHandler($client, $factory);
+
+        $key = 'key';
+        $data = array($key=>'1');
+
+        $factory->expects($this->once())
+            ->method('increment')
+            ->with($this->equalTo($key))
+            ->will($this->returnValue($data));
+
+        $bufferHandler->increment($key);
+
+        $client->expects($this->at(0))
+            ->method('send')
+            ->with($this->equalTo(array($data)));
+        $bufferHandler->send();
+
+        $client->expects($this->at(1))
+            ->method('send')
+            ->with($this->equalTo(array()));
+
+        $bufferHandler->send();
+    }
+
+}

--- a/tests/Liuggio/StatsdClient/Handler/SendHandlerTest.php
+++ b/tests/Liuggio/StatsdClient/Handler/SendHandlerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Liuggio\StatsdClient;
+
+use Liuggio\StatsdClient\Handler\BufferHandler;
+
+class SendHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOnCloseShouldEmptyTheBuffer()
+    {
+        $client = $this->getMock('\Liuggio\StatsdClient\StatsdClientInterface');
+        $factory = $this->getMock('\Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface');
+        $bufferHandler = new BufferHandler($client, $factory);
+
+        $key = 'key';
+        $data = array($key=>'1');
+
+        $factory->expects($this->once())
+            ->method('increment')
+            ->with($this->equalTo($key))
+            ->will($this->returnValue($data));
+
+        $bufferHandler->increment($key);
+
+        $client->expects($this->at(0))
+            ->method('send')
+            ->with($this->equalTo(array($data)));
+        $bufferHandler->send();
+
+        $client->expects($this->at(1))
+            ->method('send')
+            ->with($this->equalTo(array()));
+
+        $bufferHandler->close();
+    }
+
+    public function testOnSendShouldEmptyTheBuffer()
+    {
+        $client = $this->getMock('\Liuggio\StatsdClient\StatsdClientInterface');
+        $factory = $this->getMock('\Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface');
+        $bufferHandler = new BufferHandler($client, $factory);
+
+        $key = 'key';
+        $data = array($key=>'1');
+
+        $factory->expects($this->once())
+            ->method('increment')
+            ->with($this->equalTo($key))
+            ->will($this->returnValue($data));
+
+        $bufferHandler->increment($key);
+
+        $client->expects($this->at(0))
+            ->method('send')
+            ->with($this->equalTo(array($data)));
+        $bufferHandler->send();
+
+        $client->expects($this->at(1))
+            ->method('send')
+            ->with($this->equalTo(array()));
+
+        $bufferHandler->send();
+    }
+
+}

--- a/tests/Liuggio/StatsdClient/Monolog/Formatter/StatsDFormatterTest.php
+++ b/tests/Liuggio/StatsdClient/Monolog/Formatter/StatsDFormatterTest.php
@@ -2,7 +2,6 @@
 
 namespace Liuggio\StatsdClient\Tests\Monolog\Formatter;
 
-use Monolog\Logger;
 use Liuggio\StatsdClient\Monolog\Formatter\StatsDFormatter;
 
 /**
@@ -163,7 +162,6 @@ class StatsDFormatterTest extends \PHPUnit_Framework_TestCase
             'doctrine.DEBUG.Notified-event.context.baz.qux');
 
         $this->assertEquals($assert, $message);
-
 
     }
 }

--- a/tests/Liuggio/StatsdClient/Monolog/Handler/StatsDHandlerTest.php
+++ b/tests/Liuggio/StatsdClient/Monolog/Handler/StatsDHandlerTest.php
@@ -5,7 +5,6 @@ namespace Liuggio\StatsdClient\Tests\Monolog\Handler;
 use Monolog\Logger;
 use Liuggio\StatsdClient\Monolog\Handler\StatsDHandler;
 
-
 class StatsDHandlerTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -46,11 +45,10 @@ class StatsDHandlerTest extends \PHPUnit_Framework_TestCase
         $formatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
         $formatter->expects($this->any())
             ->method('format')
-            ->will($this->returnCallback(function($record) { return $record['message']; }));
+            ->will($this->returnCallback(function ($record) { return $record['message']; }));
 
         return $formatter;
     }
-
 
     protected function setup()
     {
@@ -66,7 +64,7 @@ class StatsDHandlerTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->any())
             ->method('increment')
-            ->will($this->returnCallback(function ($input){
+            ->will($this->returnCallback(function ($input) {
                 return sprintf('%s|c|1', $input);
             }));
 

--- a/tests/Liuggio/StatsdClient/PacketReducerTest.php
+++ b/tests/Liuggio/StatsdClient/PacketReducerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Liuggio\StatsdClient;
+
+use Liuggio\StatsdClient\PacketReducer;
+use Liuggio\StatsdClient\Entity\StatsdData;
+
+class PacketReducerTest extends \PHPUnit_Framework_TestCase
+{
+    public function getMockClient()
+    {
+        return $this->getMockBuilder('\Liuggio\StatsdClient\StatsdClientInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testReduceWithMaxUdpPacketSplitInTwoPacket()
+    {
+        $data = array();
+        $msg = 'A3456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789';    //1
+        $msg .= 'B23456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 '; //2
+        $msg .= 'C23456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 '; //3
+        $msg .= 'E23456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 '; //4
+        $msg .= 'F23456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c'; //500
+        $data[] = $msg;
+
+        $msg = 'Bkey:';
+        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c';
+        $data[] = $msg;
+
+        $mock = $this->getMockClient();
+        $mock->expects($this->any())
+            ->method('send')
+            ->with($this->equalTo($data));
+        $reducer = new PacketReducer($mock);
+        $reducer->send($data);
+    }
+
+    public function testReduceWithString()
+    {
+        $msg = 'A3456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789:';
+        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c';
+        $data[] = $msg;
+
+        $msg = 'B3456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789:';
+        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c';
+        $data[] = $msg;
+
+        $dataToAssert = array($data[0] . PHP_EOL . $data[1]);
+
+        $mock = $this->getMockClient();
+        $mock->expects($this->any())
+            ->method('send')
+            ->with($this->equalTo($dataToAssert));
+
+        $reducer = new PacketReducer($mock);
+        $reducer->send($data);
+    }
+
+    public function testReduceCount()
+    {
+        $entity0 = new StatsdData();
+        $entity0->setKey('key1');
+        $entity0->setValue('1');
+        $entity0->setMetric('c');
+        $data[] = $entity0;
+
+        $entity0 = new StatsdData();
+        $entity0->setKey('key2');
+        $entity0->setValue('2');
+        $entity0->setMetric('ms');
+        $data[] = $entity0;
+
+        $dataToAssert = array('key1:1|c' . PHP_EOL . 'key2:2|ms');
+
+        $mock = $this->getMockClient();
+        $mock->expects($this->any())
+            ->method('send')
+            ->with($this->equalTo($dataToAssert));
+
+        $reducer = new PacketReducer($mock);
+        $reducer->send($data);
+    }
+    public function testMultiplePacketsWithReducing()
+    {
+        $assertion = array();
+        $msg = '23456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789';
+
+        $data[] = 'A'.$msg;
+        $assertion[0] = 'A'.$msg;
+        $data[] = 'B'. $msg;
+        $assertion[0] .= PHP_EOL . 'B'.$msg;
+        $data[] = 'C'.$msg;
+        $assertion[0] .= PHP_EOL . 'C'.$msg;
+        $data[] = 'D'.$msg;
+        $assertion[0] .= PHP_EOL . 'D'.$msg;
+        $data[] = 'E'.$msg;
+        $assertion[0] .=  PHP_EOL . 'E'.$msg;
+
+        $data[] = 'F'.$msg;
+        $assertion[1] = 'F'.$msg;
+        $data[] = 'G'.$msg;
+        $assertion[1] .= PHP_EOL . 'G'.$msg;
+        $data[] = 'H'.$msg;
+        $assertion[1] .= PHP_EOL . 'H'.$msg;
+        $data[] = 'I'.$msg;
+        $assertion[1] .= PHP_EOL . 'I'.$msg;
+        $data[] = 'L'.$msg;
+        $assertion[1] .= PHP_EOL . 'L'.$msg;
+
+        $data[] = 'M'.$msg;
+        $assertion[2] = 'M'.$msg;
+        $data[] = 'N'.$msg;
+        $assertion[2] .= PHP_EOL . 'N'.$msg;
+
+        $mock = $this->getMockClient();
+        $mock->expects($this->any())
+            ->method('send')
+            ->with($this->equalTo($assertion));
+        $reducer = new PacketReducer($mock);
+
+        $reducer->send($data);
+    }
+
+    public function testSingleStatsdData()
+    {
+        $data = new StatsdData();
+        $data->setKey('key');
+        $data->setMetric(\Liuggio\StatsdClient\Entity\StatsdDataInterface::STATSD_METRIC_TIMING);
+        $data->setValue(2);
+
+        $assertion = array($data);
+
+        $mock = $this->getMockClient();
+        $mock->expects($this->any())
+            ->method('send')
+            ->with($this->equalTo($assertion));
+        $reducer = new PacketReducer($mock);
+
+        $reducer->send($data);
+    }
+}

--- a/tests/Liuggio/StatsdClient/ReadmeTest.php
+++ b/tests/Liuggio/StatsdClient/ReadmeTest.php
@@ -5,16 +5,16 @@ namespace Liuggio\StatsdClient;
 use Liuggio\StatsdClient\StatsdClient;
 use Liuggio\StatsdClient\Factory\StatsdDataFactory;
 //use Liuggio\StatsdClient\Sender\SocketSender;
-
+//use Liuggio\StatsdClient\PacketReducer;
 
 class ReadmeTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFullUsageWithObject() {
-
+    public function testFullUsageWithObject()
+    {
         $sender = $this->mockSender();
         // $sender = new Sender();
+        // $sender = new PacketReducer($sender);
 
-        // StatsdClient(SenderInterface $sender, $host = 'udp://localhost', $port = 8126, $reducePacket = true, $fail_silently = true)
         $client = new StatsdClient($sender);
         $factory = new StatsdDataFactory('\Liuggio\StatsdClient\Entity\StatsdData');
 
@@ -29,37 +29,35 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
         $client->send($data);
     }
 
-
-
-    public function testFullUsageArray() {
-        
+    public function testFullUsageArray()
+    {
         $sender = $this->mockSender();
         // $sender = new Sender();
+        // $sender = new PacketReducer($sender);
 
-        // StatsdClient(SenderInterface $sender, $host = 'localhost', $port = 8126, $protocol='udp', $reducePacket = true, $fail_silently = true)
-        $client = new StatsdClient($sender, $host = 'localhost', $port = 8126, 'udp', $reducePacket = true, $fail_silently = true);
- 
+        $client = new StatsdClient($sender);
+
         $data[] ="increment:1|c";
         $data[] ="set:value|s";
         $data[] ="gauge:value|g";
         $data[] = "timing:10|ms";
         $data[] = "decrement:-1|c";
-        $data[] ="key:1|c";         
+        $data[] ="key:1|c";
 
         // send the data as array or directly as object
         $client->send($data);
     }
 
-
-    private function mockSender() {
+    private function mockSender()
+    {
         $sender =  $this->getMock('\Liuggio\StatsdClient\Sender\SenderInterface', array('open', 'write', 'close'));
         $sender->expects($this->once())
             ->method('open')
             ->will($this->returnValue(true));
 
-        $sender->expects($this->any())  //If you set the reduce = true into the StatsdClient the write will be called once
+        $sender->expects($this->any())
             ->method('write')
-            ->will($this->returnCallBack(function($fp, $message) {
+            ->will($this->returnCallBack(function ($fp, $message) {
              //  echo PHP_EOL . "- " . $message;
         }));
 

--- a/tests/Liuggio/StatsdClient/StatsdClientTest.php
+++ b/tests/Liuggio/StatsdClient/StatsdClientTest.php
@@ -8,14 +8,15 @@ use Liuggio\StatsdClient\Entity\StatsdData;
 class StatsdClientTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function mockSenderWithAssertionOnWrite($messageToAssert=null) {
-
+    public function mockSenderWithAssertionOnWrite($messageToAssert)
+    {
         $mock = $this->getMockBuilder('\Liuggio\StatsdClient\Sender\SocketSender') ->disableOriginalConstructor() ->getMock();
 
         $phpUnit = $this;
         $mock->expects($this->any())
             ->method('open')
             ->will($this->returnValue(true));
+
         // if the input is an array expects a call foreach item
         if (is_array($messageToAssert)) {
             $index = 0;
@@ -23,30 +24,33 @@ class StatsdClientTest extends \PHPUnit_Framework_TestCase
                 $index++;
                 $mock->expects($this->at($index))
                     ->method('write')
-                    ->will($this->returnCallBack(function($fp, $message) use ($phpUnit, $oneMessage) {
-                      $phpUnit->assertEquals($message, $oneMessage);
-                }));
+                    ->with($this->anything(),
+                           $this->equalTo($oneMessage)
+                    );
             }
-        } else if (null !== $messageToAssert){
+        } elseif (null !== $messageToAssert) {
             // if the input is a string expects only once
             $mock->expects($this->once())
                 ->method('write')
-                ->will($this->returnCallBack(function($fp, $message) use ($phpUnit, $messageToAssert) {
-                 $phpUnit->assertEquals($message, $messageToAssert);
-            }));
+                ->with($this->anything(),
+                    $this->equalTo($messageToAssert)
+                );
         }
+
         return $mock;
     }
 
-    public function mockStatsdClientWithAssertionOnWrite($messageToAssert) {
-
+    public function mockStatsdClientWithAssertionOnWrite($messageToAssert)
+    {
         $mockSender = $this->mockSenderWithAssertionOnWrite($messageToAssert);
 
-        return new StatsdClient($mockSender, false, false);
+        $statsdClient = new StatsdClient($mockSender, null, false);
+
+        return $statsdClient;
     }
 
-    public function mockFactory() {
-
+    public function mockFactory()
+    {
         $mock =  $this->getMock('\Liuggio\StatsdClient\Factory\StatsdDataFactory', array('timing'));
 
         $statsData = new StatsdData();
@@ -54,7 +58,6 @@ class StatsdClientTest extends \PHPUnit_Framework_TestCase
         $statsData->setValue('1');
         $statsData->setMetric('ms');
 
-        $phpUnit = $this;
         $mock->expects($this->any())
             ->method('timing')
             ->will($this->returnValue($statsData));
@@ -92,6 +95,7 @@ class StatsdClientTest extends \PHPUnit_Framework_TestCase
             array($stats1, array("keyTiming:1|ms", "keyIncrement:1|c")),
         );
     }
+
     public static function providerSend()
     {
         return array(
@@ -103,8 +107,8 @@ class StatsdClientTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provider
      */
-    public function testPrepareAndSend($statsdInput, $assertion) {
-
+    public function testPrepareAndSend($statsdInput, $assertion)
+    {
         $statsdMock = $this->mockStatsdClientWithAssertionOnWrite($assertion);
         $statsdMock->send($statsdInput);
     }
@@ -112,117 +116,9 @@ class StatsdClientTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider providerSend
      */
-    public function testSend($array, $assertion) {
-
+    public function testSend($array, $assertion)
+    {
         $statsdMock = $this->mockStatsdClientWithAssertionOnWrite($assertion);
         $statsdMock->send($array);
-    }
-
-    public function testReduceCount()
-    {
-        $statsd = $this->mockStatsdClientWithAssertionOnWrite(null);
-
-        $entity0 = new StatsdData();
-        $entity0->setKey('key1');
-        $entity0->setValue('1');
-        $entity0->setMetric('c');
-        $array0[] = $entity0;
-
-        $entity0 = new StatsdData();
-        $entity0->setKey('key2');
-        $entity0->setValue('2');
-        $entity0->setMetric('ms');
-        $array0[] = $entity0;
-
-        $reducedMessage = array('key1:1|c' . PHP_EOL . 'key2:2|ms');
-
-        $this->assertEquals($statsd->reduceCount($array0), $reducedMessage);
-
-    }
-
-    public function testReduceWithString()
-    {
-        $statsd = $this->mockStatsdClientWithAssertionOnWrite(null);
-
-        $msg = 'A3456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789:';
-        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c';
-        $array0[] = $msg;
-
-        $msg = 'B3456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789:';
-        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c';
-        $array0[] = $msg;
-        $reduced = $statsd->reduceCount($array0);
-        $combined = $array0[0] . PHP_EOL . $array0[1];
-        $this->assertEquals($combined, $reduced[0]);
-    }
-
-
-    public function testReduceWithMaxUdpPacketSplitInTwoPacket()
-    {
-        $statsd = $this->mockStatsdClientWithAssertionOnWrite(null);
-
-        $msg = 'A3456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789';    //1
-        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 '; //2
-        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 '; //3
-        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 '; //4
-        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c'; //500
-        $array0[] = $msg;
-
-        $msg = 'Bkey:';
-        $msg .= '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789|c';
-        $array0[] = $msg;
-
-        $reduced = $statsd->reduceCount($array0);
-
-        $this->assertEquals($array0[0], $reduced[0]);
-        $this->assertEquals($array0[1], $reduced[1]);
-    }
-
-
-
-    public function testMultiplePacketsWithReducing()
-    {
-
-        $msg = 'A23456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789';
-        $array0[] = $msg;
-        $array0[] = $msg;
-        $array0[] = $msg;
-        $array0[] = $msg;
-        $array0[] = $msg;
-        $array0[] = $msg;
-        $array0[] = $msg;
-        $array0[] = $msg;
-
-        $total = count($array0) * strlen($msg);
-
-        $reducedPacketsAssertion = (int) ceil($total / StatsdClientInterface::MAX_UDP_SIZE_STR);
-
-
-        $mockSender = $this->mockSenderWithAssertionOnWrite();
-        $statsd = new  StatsdClient($mockSender, true, false);
-        $reduced = $statsd->reduceCount($array0);
-
-        $this->assertEquals($reducedPacketsAssertion, count($reduced));
-    }
-
-    public function testSampleRate()
-    {
-        $senderMock = $this->getMock('Liuggio\StatsdClient\Sender\SenderInterface');
-        $senderMock
-            ->expects($this->once())
-            ->method('open')
-            ->will($this->returnValue(true))
-        ;
-        $senderMock
-            ->expects($this->once())
-            ->method('write')
-            ->with($this->anything(), 'foo|@0.2')
-        ;
-        $client = new StatsdClient($senderMock, false, false);
-
-        $client->send(
-            'foo',
-            0.2
-        );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
 
-
 $loader = require_once __DIR__ . "/../vendor/autoload.php";
 $loader->add('Liuggio\\', __DIR__);


### PR DESCRIPTION
### The version 2.0

In this version I added the handler that can be used to facilitate the sending liuggio/StatsDClientBundle#40,
or also using it to buffer all packets until closing the handler, related to https://github.com/liuggio/StatsDClientBundle/issues/37

This fix also #21.

### Example 
```php
$sender = SocketSender('localhost', 8126) // new sender using socket.
$client = new StatsdClient($sender);
// add decorator to reduce packets.
$client = new PacketReducer($client);
$factory = new StatsdDataFactory();

// BufferHandler will set the data into the buffer until `send` or `close` or `_deconstruct` is called
$bufferHandler = new BufferHandler($client, $factory);
$bufferHandler->timing('usageTime', 100);

// SendHandler will send immediately the data.
$sendHandler = new SendHandler($client, $factory);
$sendHandler->timing('usageTime', 100);
```
