### PR TITLE
Simple service

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,28 +46,27 @@ Be careful, see the [Upgrading section](Readme.md#upgrade) for <= v1.0.4, there'
 ```php
 use Liuggio\StatsdClient\StatsdClient,
     Liuggio\StatsdClient\Factory\StatsdDataFactory,
-    Liuggio\StatsdClient\Sender\SocketSender;
+    Liuggio\StatsdClient\Sender\SocketSender,
+    Liuggio\StatsdClient\Service\StatsdService;
 // use Liuggio\StatsdClient\Sender\SysLogSender;
 
 $sender = new SocketSender(/*'localhost', 8126, 'udp'*/);
 // $sender = new SysLogSender(); // enabling this, the packet will not send over the socket
 
-$client = new StatsdClient($sender);
+$client  = new StatsdClient($sender);
 $factory = new StatsdDataFactory('\Liuggio\StatsdClient\Entity\StatsdData');
+$service = new StatsdService($client, $factory);
 
-// create the data with the factory
-$data[] = $factory->timing('usageTime', 100);
-$data[] = $factory->increment('visitor');
-$data[] = $factory->decrement('click');
-$data[] = $factory->gauge('gaugor', 333);
-$data[] = $factory->set('uniques', 765);
+// create the metrics with the service
+$service->timing('usageTime', 100);
+$service->increment('visitor');
+$service->decrement('click');
+$service->gauge('gaugor', 333);
+$service->set('uniques', 765);
 
-// send the data as array or directly as object
-$client->send($data);
+// send the data to statsd
+$service->flush();
 
-// You can wrap these in the StatsdService
-$service = new \Liuggio\StatsdClient\Service\StatsdService($client, $factory);
-$service->timing('usageTime', 100)->flush();
 ```
 
 ### Usage with Monolog

--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,10 @@ $data[] = $factory->set('uniques', 765);
 
 // send the data as array or directly as object
 $client->send($data);
+
+// You can wrap these in the StatsdService
+$service = new \Liuggio\StatsdClient\Service\StatsdService($client, $factory);
+$service->timing('usageTime', 100)->flush();
 ```
 
 ### Usage with Monolog

--- a/src/Liuggio/StatsdClient/Service/StatsdService.php
+++ b/src/Liuggio/StatsdClient/Service/StatsdService.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Liuggio\StatsdClient\Service;
+
+use Liuggio\StatsdClient\Entity\StatsdDataInterface;
+use Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface;
+use Liuggio\StatsdClient\StatsdClient;
+use Liuggio\StatsdClient\Entity\StatsdData;
+
+/**
+ * Simplifies access to StatsD client and factory, buffers all data.
+ */
+class StatsDService implements StatsdDataFactoryInterface
+{
+    /**
+     * @var \Liuggio\StatsdClient\StatsdClient
+     */
+    protected $client;
+
+    /**
+     * @var \Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface
+     */
+    protected $factory;
+
+    /**
+     * @var StatsdData[]
+     */
+    protected $buffer = array();
+
+    /**
+     * @param StatsdClient               $client
+     * @param StatsdDataFactoryInterface $factory
+     */
+    public function __construct(StatsdClient $client, StatsdDataFactoryInterface $factory)
+    {
+        $this->client = $client;
+        $this->factory = $factory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function timing($key, $time)
+    {
+        array_push($this->buffer, $this->factory->timing($key, $time));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function gauge($key, $value)
+    {
+        array_push($this->buffer, $this->factory->gauge($key, $value));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $value)
+    {
+        array_push($this->buffer, $this->factory->set($key, $value));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment($key)
+    {
+        array_push($this->buffer, $this->factory->increment($key));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decrement($key)
+    {
+        array_push($this->buffer, $this->factory->decrement($key));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateCount($key, $delta)
+    {
+        array_push($this->buffer, $this->factory->updateCount($key, $delta));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function produceStatsdData($key, $value = 1, $metric = StatsdDataInterface::STATSD_METRIC_COUNT)
+    {
+        throw new \BadFunctionCallException('produceStatsdData is not implemented');
+    }
+
+    /**
+     * Send all buffered data to statsd.
+     *
+     * @return $this
+     */
+    public function flush()
+    {
+        $this->client->send($this->buffer);
+        $this->buffer = array();
+
+        return $this;
+    }
+}

--- a/tests/Liuggio/StatsdClient/Service/StatsdServiceTest.php
+++ b/tests/Liuggio/StatsdClient/Service/StatsdServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Liuggio\StatsdClient\Entity;
+
+use Liuggio\StatsdClient\Service\StatsdService;
+
+class StatsdServiceTest extends \PHPUnit_Framework_TestCase
+{
+    private $clientMock;
+    private $factoryMock;
+
+    public function setUp()
+    {
+        $this->clientMock = $this->getMockBuilder('Liuggio\StatsdClient\StatsdClient')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->factoryMock = $this->getMockBuilder('Liuggio\StatsdClient\Factory\StatsdDataFactoryInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testFactoryImplementation()
+    {
+        // Configure the client mock.
+        $this->factoryMock->expects($this->once())->method('timing');
+        $this->factoryMock->expects($this->once())->method('gauge');
+        $this->factoryMock->expects($this->once())->method('set');
+        $this->factoryMock->expects($this->once())->method('increment');
+        $this->factoryMock->expects($this->once())->method('decrement');
+        $this->factoryMock->expects($this->once())->method('updateCount');
+
+        // Actual test
+        $dut = new StatsdService($this->clientMock, $this->factoryMock);
+        $dut->timing('foo.bar', 123);
+        $dut->gauge('foo.bar', 123);
+        $dut->set('foo.bar', 123);
+        $dut->increment('foo.bar');
+        $dut->decrement('foo.bar');
+        $dut->updateCount('foo.bar', 123);
+    }
+
+    public function testFlush()
+    {
+        $data = new StatsdData();
+        $this->factoryMock->expects($this->once())->method('timing')->willReturn($data);
+        $this->clientMock->expects($this->once())->method('send')
+            ->with($this->equalTo(array($data)));
+
+        // Actual test
+        $dut = new StatsdService($this->clientMock, $this->factoryMock);
+        $dut->timing('foobar', 123);
+        $dut->flush();
+    }
+}


### PR DESCRIPTION
As requested in https://github.com/liuggio/StatsDClientBundle/pull/46, moved code here.

> At lafourchette, we like when using a service is fast and concise, and container access is reduced to the minimum. That's why we felt right to add a new service which takes the same responsabilities as the factory and the client.
> 
> Added the documentation to detail how it works.

Added tests.