### PR TITLE
Set the default port to the default one used by StatsD

### DIFF
--- a/src/Liuggio/StatsdClient/Sender/SocketSender.php
+++ b/src/Liuggio/StatsdClient/Sender/SocketSender.php
@@ -10,7 +10,7 @@ Class SocketSender implements SenderInterface
     private $host;
     private $protocol;
 
-    public function __construct($hostname = 'localhost', $port = 8126, $protocol = 'udp')
+    public function __construct($hostname = 'localhost', $port = 8125, $protocol = 'udp')
     {
         $this->host = $hostname;
         $this->port = $port;


### PR DESCRIPTION
This pull requests changes the default port used by `Liuggio\StatsdClient\Sender\SocketSender` from `8126` to `8125` - this the default port for StatsD service.
