### PR TITLE
use json_encode for parameter when formating log content

### DIFF
--- a/src/Liuggio/StatsdClient/Monolog/Formatter/StatsDFormatter.php
+++ b/src/Liuggio/StatsdClient/Monolog/Formatter/StatsDFormatter.php
@@ -73,12 +73,18 @@ class StatsDFormatter extends LineFormatter
         // creating more rows for context content
         if ($this->logContext && isset($vars['context'])) {
             foreach ($vars['context'] as $key => $parameter) {
+                if (!is_string($parameter)) {
+                    $parameter = json_encode($parameter);
+                }
                 $output[] = sprintf("%s.context.%s.%s", $firstRow, $key, $parameter);
             }
         }
         // creating more rows for extra content
         if ($this->logExtra && isset($vars['extra'])) {
             foreach ($vars['extra'] as $key => $parameter) {
+                if (!is_string($parameter)) {
+                    $parameter = json_encode($parameter);
+                }
                 $output[] = sprintf("%s.extra.%s.%s", $firstRow, $key, $parameter);
             }
         }


### PR DESCRIPTION
sometimes error message might contain nested array, and you might get 'Array to string conversion' notice

additionally you get the benefit of displaying Boolean values in log messages