### PR TITLE
Avoid undefined variable warning in StatsdClient::send()

### DIFF
--- a/src/Liuggio/StatsdClient/StatsdClient.php
+++ b/src/Liuggio/StatsdClient/StatsdClient.php
@@ -140,13 +140,13 @@ class StatsdClient implements StatsdClientInterface
         if ($this->getReducePacket()) {
             $data = $this->reduceCount($data);
         }
+        $written = 0;
         //failures in any of this should be silently ignored if ..
         try {
             $fp = $this->getSender()->open();
             if (!$fp) {
                 return;
             }
-            $written = 0;
             foreach ($data as $key => $message) {
                 $written += $this->getSender()->write($fp, $message);
             }


### PR DESCRIPTION
Avoid warning when opening a sender fails and failSilently is set.