### PR TITLE
Fix PHP 5.3.3 builds on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     fast_finish: true
 
 before_script:
+  - if [ "$TRAVIS_PHP_VERSION" = "5.3.3" ]; then composer config disable-tls true; composer config secure-http false; fi
   - if [ "$deps" == "low" ]; then composer update --prefer-source --prefer-lowest --prefer-stable; fi
   - if [ "$deps" != "low" ]; then composer install --prefer-source; fi
 


### PR DESCRIPTION
Run `composer config disable-tls true` if the build is on PHP 5.3.3 since
it doesn't have the openssl extension installed