### PR TITLE
Fixed default sampling function.

### DIFF
--- a/src/Liuggio/StatsdClient/Service/StatsdService.php
+++ b/src/Liuggio/StatsdClient/Service/StatsdService.php
@@ -55,7 +55,7 @@ class StatsdService implements StatsdDataFactoryInterface
 
     /**
      * Actually defines the sampling rate used by the service.
-     * If set to 0.1, the service will automatically discard 10%
+     * If set to 0.1, the service will automatically discard 90%
      * of the incoming metrics. It will also automatically flag these
      * as sampled data to statsd.
      *
@@ -68,7 +68,7 @@ class StatsdService implements StatsdDataFactoryInterface
         }
         $this->samplingRate = $samplingRate;
         $this->samplingFunction = function($min, $max){
-            return rand($min, $max);
+            return rand($min, $max - 1);
         };
     }
 


### PR DESCRIPTION
For sampling rate 0.5 function gets arguments (0,2) and should return only 0 or 1 (not 2).
Still, this is not correct for sampling rates like 0.4, (because of floor in appendToBuffer) but fix could break BC...