### PR TITLE
StatsdClient: Fix use of "self" in callable (v1.1.x)

### DIFF
--- a/src/Liuggio/StatsdClient/StatsdClient.php
+++ b/src/Liuggio/StatsdClient/StatsdClient.php
@@ -91,7 +91,7 @@ class StatsdClient implements StatsdClientInterface
     public function reduceCount($arrayData)
     {
         if (is_array($arrayData)) {
-            $arrayData = array_reduce($arrayData, "self::doReduce", array());
+            $arrayData = array_reduce($arrayData, array(self::class, "doReduce"), array());
         }
 
         return $arrayData;


### PR DESCRIPTION
Fixes https://github.com/liuggio/statsd-php-client/issues/60