### PR TITLE
composer.json: Move to PSR-4 autoload (v1.1.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     ],
     "autoload": {
-        "psr-0": {"Liuggio": "src/"}
+        "psr-4": {"Liuggio\\": "src/Liuggio/"}
     },
     "autoload-dev": {
-      "psr-0": {"Liuggio": "tests/"}
+      "psr-4": {"Liuggio\\": "tests/Liuggio/"}
     },
     "require-dev": {
         "monolog/monolog": ">=1.2.0",


### PR DESCRIPTION
Fixes https://github.com/liuggio/statsd-php-client/issues/50

Probably should move the files up a level (ie from `src/Liuggio/` to just `src/` etc, but that can be done later